### PR TITLE
Fix missing ChatOpenAI import

### DIFF
--- a/agent_utils/vector_store.py
+++ b/agent_utils/vector_store.py
@@ -1,6 +1,7 @@
 from langchain_community.embeddings import OpenAIEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_community.document_loaders import CSVLoader
+from langchain_openai import ChatOpenAI
 import os
 
 VECTOR_DB_PATH = "chat_data/vector_store"


### PR DESCRIPTION
## Summary
- fix vector store ChatOpenAI import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_6850b2a5426c8332b87140f8a62cf8c4